### PR TITLE
Refactor/contract verifier flow

### DIFF
--- a/contract/contracts/SSI.sol
+++ b/contract/contracts/SSI.sol
@@ -166,6 +166,7 @@ contract SSI {
         VerificationStatus status;
         uint256 createdAt;
         uint256 expiresAt;
+        string presentationId;
         bool fulfilled;
     }
 
@@ -360,17 +361,21 @@ contract SSI {
     }
 
     function getPresentationHash(
+        string memory presentationId,
         string memory verificationRequestId,
         string[] memory credentialIds,
         string memory citizenDid,
+        string memory verifierDid,
         string memory nonce
     ) public view returns (bytes32) {
         return
             keccak256(
                 abi.encode(
+                    presentationId,
                     verificationRequestId,
                     credentialIds,
                     citizenDid,
+                    verifierDid,
                     nonce,
                     address(this),
                     block.chainid
@@ -686,6 +691,21 @@ contract SSI {
     function createVerificationRequest(
         VerificationRequest memory request
     ) public {
+        string memory senderDid = userAddressToDId[msg.sender];
+        User memory user = users[senderDid];
+
+        require(bytes(request.verificationRequestId).length != 0);
+        require(bytes(senderDid).length != 0);
+        require(user.role == Role.VERIFIER);
+        require(user.active);
+        require(bytes(request.nonce).length != 0);
+        require(request.requestedClaims.length > 0);
+        require(request.expiresAt > block.timestamp);
+
+        request.verifierDid = senderDid;
+        request.status = VerificationStatus.REQUESTED;
+        request.fulfilled = false;
+        request.presentationId = "";
         verificationRequests[request.verificationRequestId] = request;
     }
 
@@ -695,35 +715,43 @@ contract SSI {
         return verificationRequests[requestId];
     }
 
-    // function submitPresentation(
-    //     VerifiablePresentation memory presentation
-    // ) public {
-    //     presentations[presentation.presentationId] = presentation;
-    // }
-
     function submitPresentation(
         VerifiablePresentation memory presentation
     ) public {
+        string memory senderDid = userAddressToDId[msg.sender];
+        User memory user = users[senderDid];
+        VerificationRequest storage req = verificationRequests[
+            presentation.verificationRequestId
+        ];
+
+        require(bytes(senderDid).length != 0);
+        require(user.role == Role.CITIZEN);
+        require(user.active);
+        require(bytes(req.verificationRequestId).length != 0);
+        require(bytes(req.presentationId).length == 0);
+        require(
+            keccak256(bytes(senderDid)) ==
+                keccak256(bytes(presentation.citizenDid))
+        );
+        require(
+            keccak256(bytes(req.verifierDid)) ==
+                keccak256(bytes(presentation.verifierDid))
+        );
+        require(block.timestamp <= req.expiresAt);
+
         require(
             bytes(presentations[presentation.presentationId].presentationId)
-                .length == 0,
-            "Exists"
+                .length == 0
         );
 
         presentations[presentation.presentationId] = presentation;
+
+        if (bytes(req.citizenDid).length == 0) {
+            req.citizenDid = presentation.citizenDid;
+        }
+
+        req.presentationId = presentation.presentationId;
     }
-
-    // function verifyPresentation(
-    //     string memory presentationId
-    // ) public view returns (bool) {
-    //     VerifiablePresentation memory p = presentations[presentationId];
-
-    //     if (p.expiresAt < block.timestamp) {
-    //         return false;
-    //     }
-
-    //     return true;
-    // }
 
     function verifyPresentation(
         string memory presentationId
@@ -733,69 +761,100 @@ contract SSI {
             p.verificationRequestId
         ];
 
-        require(bytes(p.presentationId).length != 0, "Invalid presentation");
-        require(bytes(vr.verificationRequestId).length != 0, "Invalid request");
+        require(bytes(p.presentationId).length != 0);
+        require(bytes(vr.verificationRequestId).length != 0);
+        require(bytes(vr.presentationId).length != 0);
+
+        string memory verifierDid = userAddressToDId[msg.sender];
+        User memory verifier = users[verifierDid];
+        require(bytes(verifier.did).length != 0);
+        require(verifier.role == Role.VERIFIER);
+        require(verifier.active);
+        require(
+            keccak256(bytes(verifierDid)) == keccak256(bytes(vr.verifierDid))
+        );
 
         if (block.timestamp > p.expiresAt || block.timestamp > vr.expiresAt) {
+            vr.status = VerificationStatus.REJECTED;
             return false;
         }
 
-        require(!vr.fulfilled, "Already fulfilled");
+        require(!vr.fulfilled);
 
         require(
-            keccak256(bytes(p.citizenDid)) == keccak256(bytes(vr.citizenDid)),
-            "Citizen mismatch"
+            keccak256(bytes(p.presentationId)) ==
+                keccak256(bytes(vr.presentationId))
+        );
+
+        if (bytes(vr.citizenDid).length == 0) {
+            vr.citizenDid = p.citizenDid;
+        }
+
+        require(bytes(vr.citizenDid).length != 0);
+
+        require(
+            keccak256(bytes(p.citizenDid)) == keccak256(bytes(vr.citizenDid))
         );
 
         require(
-            keccak256(bytes(p.nonce)) == keccak256(bytes(vr.nonce)),
-            "Nonce mismatch"
+            keccak256(bytes(p.verifierDid)) == keccak256(bytes(vr.verifierDid))
         );
+
+        require(keccak256(bytes(p.nonce)) == keccak256(bytes(vr.nonce)));
 
         bytes32 hash = getPresentationHash(
+            p.presentationId,
             p.verificationRequestId,
             p.credentialIds,
             p.citizenDid,
+            p.verifierDid,
             p.nonce
         );
 
         address signer = recoverSigner(hash, p.citizenSignature);
         string memory signerDid = userAddressToDId[signer];
+        User memory signerUser = users[signerDid];
 
-        require(
-            keccak256(bytes(signerDid)) == keccak256(bytes(p.citizenDid)),
-            "Invalid signer"
-        );
+        require(bytes(signerDid).length != 0);
+        require(signerUser.active);
+        require(signerUser.role == Role.CITIZEN);
+
+        require(keccak256(bytes(signerDid)) == keccak256(bytes(p.citizenDid)));
+
+        require(p.credentialIds.length > 0);
 
         for (uint i = 0; i < p.credentialIds.length; i++) {
             Credential memory cred = credentials[p.credentialIds[i]];
+            ClaimRequest storage claimRequest = claimRequests[cred.requestId];
 
-            require(bytes(cred.credentialId).length != 0, "Invalid credential");
-            require(
-                cred.status == CredentialStatus.ACTIVE,
-                "Credential invalid"
-            );
+            require(bytes(cred.credentialId).length != 0);
+            require(cred.status == CredentialStatus.ACTIVE);
 
             require(
                 keccak256(bytes(cred.citizenDid)) ==
-                    keccak256(bytes(p.citizenDid)),
-                "Ownership mismatch"
+                    keccak256(bytes(p.citizenDid))
             );
 
-            bool matchFound = false;
+            require(cred.signatures.length > 0);
+
+            require(bytes(claimRequest.requestId).length != 0);
+
+            bool requestedClaimFound = false;
             for (uint j = 0; j < vr.requestedClaims.length; j++) {
                 if (
                     keccak256(bytes(cred.claimId)) ==
                     keccak256(bytes(vr.requestedClaims[j]))
                 ) {
-                    matchFound = true;
+                    requestedClaimFound = true;
                     break;
                 }
             }
-            require(matchFound, "Claim not requested");
+
+            require(requestedClaimFound);
         }
 
         vr.fulfilled = true;
+        vr.status = VerificationStatus.APPROVED;
         p.verified = true;
 
         return true;


### PR DESCRIPTION
verifier flow refactored to our plan

FYR:
check out this flow before starting the integration, if you feel like any changes are required, do not merge this pr

1. Verifier creates the request

Function: createVerificationRequest
Purpose: the verifier opens a verification session on-chain.
What it stores:
verificationRequestId
verifierDid
requestedClaims
nonce
expiresAt
In your QR, you should encode the request reference and verifier details so the citizen can scan once and know what is being asked.
2. Citizen reads the request

Function: getVerificationRequest
Purpose: the citizen loads the request details after scanning the QR.
The citizen UI uses this to show:
which verifier is asking
which claims are requested
the nonce
expiry
Since the request is public on-chain, this is the main read step before building the proof.
3. Citizen looks up credentials

Function: getCredentialsByCitizen
Optional function: getCredential
Purpose: the citizen selects the credentials that satisfy the requested claims.
The app should filter credentials by:
claimId
ACTIVE status
ownership by the citizen
4. Citizen creates the presentation hash

Function: getPresentationHash
Purpose: builds the exact message that the citizen must sign.
This hash is tied to:
presentationId
verificationRequestId
credentialIds
citizenDid
verifierDid
nonce
The citizen signs this off-chain, then submits the signed presentation.
5. Citizen submits the presentation

Function: submitPresentation
Purpose: stores the citizen’s verifiable presentation on-chain.
It checks:
sender is the citizen
request exists
verifier matches
request has not expired
presentation is not duplicated
It then links the presentation back to the verification request.
6. Verifier validates the presentation

Function: verifyPresentation
Purpose: verifier confirms the citizen’s proof.
It checks:
caller is the assigned verifier
request exists
presentation exists and is linked
citizen DID matches
verifier DID matches
nonce matches
recovered signer is the citizen
each credential exists
each credential is ACTIVE
each credential belongs to the citizen
each credential claim is one of the requested claims
If valid:
request is marked fulfilled
request status becomes APPROVED
presentation is marked verified
7. Verifier reads status / UI data

Function: getVerificationRequest
Function: presentations mapping getter
Function: getCredential
Function: getUser
Purpose: show verification state in the UI.
In the current simplified contract, there is no dedicated metadata helper anymore, so the UI can read:
request info from getVerificationRequest
presentation info from the public presentations mapping getter
credential details from getCredential
user details from getUser
Suggested integration order

createVerificationRequest
show QR containing the request identifiers
citizen calls getVerificationRequest
citizen calls getCredentialsByCitizen
citizen signs getPresentationHash
citizen calls submitPresentation
verifier calls verifyPresentation
UI refreshes using getVerificationRequest and presentations



feed the above flow to the claude code.

@ashfaqjani916 